### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/aging/due.py
+++ b/aging/due.py
@@ -60,7 +60,7 @@ except Exception as e:
     if type(e).__name__ != 'ImportError':
         import logging
         logging.getLogger("duecredit").error(
-            "Failed to import duecredit due to %s" % str(e))
+            "Failed to import duecredit due to {0!s}".format(str(e)))
     # Initiate due stub
     due = InactiveDueCreditCollector()
     BibTeX = Doi = Url = _donothing_func

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -120,7 +120,7 @@ class NumpyDocString(collections.Mapping):
 
     def __setitem__(self, key, val):
         if key not in self._parsed_data:
-            warn("Unknown section %s" % key)
+            warn("Unknown section {0!s}".format(key))
         else:
             self._parsed_data[key] = val
 
@@ -219,7 +219,7 @@ class NumpyDocString(collections.Mapping):
                     return g[3], None
                 else:
                     return g[2], g[1]
-            raise ValueError("%s is not a item name" % text)
+            raise ValueError("{0!s} is not a item name".format(text))
 
         def push_item(name, rest):
             if not name:
@@ -360,7 +360,7 @@ class NumpyDocString(collections.Mapping):
             out += self._str_header(name)
             for param, param_type, desc in self[name]:
                 if param_type:
-                    out += ['%s : %s' % (param, param_type)]
+                    out += ['{0!s} : {1!s}'.format(param, param_type)]
                 else:
                     out += [param]
                 out += self._str_indent(desc)
@@ -383,16 +383,16 @@ class NumpyDocString(collections.Mapping):
         last_had_desc = True
         for func, desc, role in self['See Also']:
             if role:
-                link = ':%s:`%s`' % (role, func)
+                link = ':{0!s}:`{1!s}`'.format(role, func)
             elif func_role:
-                link = ':%s:`%s`' % (func_role, func)
+                link = ':{0!s}:`{1!s}`'.format(func_role, func)
             else:
-                link = "`%s`_" % func
+                link = "`{0!s}`_".format(func)
             if desc or last_had_desc:
                 out += ['']
                 out += [link]
             else:
-                out[-1] += ", %s" % link
+                out[-1] += ", {0!s}".format(link)
             if desc:
                 out += self._str_indent([' '.join(desc)])
                 last_had_desc = True
@@ -404,11 +404,11 @@ class NumpyDocString(collections.Mapping):
     def _str_index(self):
         idx = self['index']
         out = []
-        out += ['.. index:: %s' % idx.get('default', '')]
+        out += ['.. index:: {0!s}'.format(idx.get('default', ''))]
         for section, references in idx.items():
             if section == 'default':
                 continue
-            out += ['   :%s: %s' % (section, ', '.join(references))]
+            out += ['   :{0!s}: {1!s}'.format(section, ', '.join(references))]
         return out
 
     def __str__(self, func_role=''):
@@ -467,9 +467,9 @@ class FunctionDoc(NumpyDocString):
                     argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
-                signature = '%s%s' % (func_name, argspec)
+                signature = '{0!s}{1!s}'.format(func_name, argspec)
             except TypeError as e:
-                signature = '%s()' % func_name
+                signature = '{0!s}()'.format(func_name)
             self['Signature'] = signature
 
     def get_func(self):
@@ -491,8 +491,8 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if self._role not in roles:
-                print("Warning: invalid role %s" % self._role)
-            out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
+                print("Warning: invalid role {0!s}".format(self._role))
+            out += '.. {0!s}:: {1!s}\n    \n\n'.format(roles.get(self._role, ''),
                                              func_name)
 
         out += super(FunctionDoc, self).__str__(func_role=self._role)
@@ -506,7 +506,7 @@ class ClassDoc(NumpyDocString):
     def __init__(self, cls, doc=None, modulename='', func_doc=FunctionDoc,
                  config={}):
         if not inspect.isclass(cls) and cls is not None:
-            raise ValueError("Expected a class or None, but got %r" % cls)
+            raise ValueError("Expected a class or None, but got {0!r}".format(cls))
         self._cls = cls
 
         self.show_inherited_members = config.get(

--- a/doc/sphinxext/docscrape_sphinx.py
+++ b/doc/sphinxext/docscrape_sphinx.py
@@ -23,7 +23,7 @@ class SphinxDocString(NumpyDocString):
     def _str_signature(self):
         return ['']
         if self['Signature']:
-            return ['``%s``' % self['Signature']] + ['']
+            return ['``{0!s}``'.format(self['Signature'])] + ['']
         else:
             return ['']
 
@@ -39,7 +39,7 @@ class SphinxDocString(NumpyDocString):
             out += self._str_field_list(name)
             out += ['']
             for param,param_type,desc in self[name]:
-                out += self._str_indent(['**%s** : %s' % (param.strip(),
+                out += self._str_indent(['**{0!s}** : {1!s}'.format(param.strip(),
                                                           param_type)])
                 out += ['']
                 out += self._str_indent(desc,8)
@@ -62,18 +62,18 @@ class SphinxDocString(NumpyDocString):
         """
         out = []
         if self[name]:
-            out += ['.. rubric:: %s' % name, '']
+            out += ['.. rubric:: {0!s}'.format(name), '']
             prefix = getattr(self, '_name', '')
 
             if prefix:
-                prefix = '~%s.' % prefix
+                prefix = '~{0!s}.'.format(prefix)
 
             autosum = []
             others = []
             for param, param_type, desc in self[name]:
                 param = param.strip()
                 if not self._obj or hasattr(self._obj, param):
-                    autosum += ["   %s%s" % (prefix, param)]
+                    autosum += ["   {0!s}{1!s}".format(prefix, param)]
                 else:
                     others.append((param, param_type, desc))
 
@@ -85,7 +85,7 @@ class SphinxDocString(NumpyDocString):
                 maxlen_0 = max([len(x[0]) for x in others])
                 maxlen_1 = max([len(x[1]) for x in others])
                 hdr = "="*maxlen_0 + "  " + "="*maxlen_1 + "  " + "="*10
-                fmt = '%%%ds  %%%ds  ' % (maxlen_0, maxlen_1)
+                fmt = '%{0:d}s  %{1:d}s  '.format(maxlen_0, maxlen_1)
                 n_indent = maxlen_0 + maxlen_1 + 4
                 out += [hdr]
                 for param, param_type, desc in others:
@@ -126,14 +126,14 @@ class SphinxDocString(NumpyDocString):
         if len(idx) == 0:
             return out
 
-        out += ['.. index:: %s' % idx.get('default','')]
+        out += ['.. index:: {0!s}'.format(idx.get('default',''))]
         for section, references in idx.iteritems():
             if section == 'default':
                 continue
             elif section == 'refguide':
-                out += ['   single: %s' % (', '.join(references))]
+                out += ['   single: {0!s}'.format((', '.join(references)))]
             else:
-                out += ['   %s: %s' % (section, ','.join(references))]
+                out += ['   {0!s}: {1!s}'.format(section, ','.join(references))]
         return out
 
     def _str_references(self):
@@ -155,7 +155,7 @@ class SphinxDocString(NumpyDocString):
                 m = re.match(r'.. \[([a-z0-9._-]+)\]', line, re.I)
                 if m:
                     items.append(m.group(1))
-            out += ['   ' + ", ".join(["[%s]_" % item for item in items]), '']
+            out += ['   ' + ", ".join(["[{0!s}]_".format(item) for item in items]), '']
         return out
 
     def _str_examples(self):

--- a/doc/sphinxext/github.py
+++ b/doc/sphinxext/github.py
@@ -37,7 +37,7 @@ def make_link_node(rawtext, app, type, slug, options):
         if not base.endswith('/'):
             base += '/'
     except AttributeError as err:
-        raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
+        raise ValueError('github_project_url configuration value is not set ({0!s})'.format(str(err)))
 
     ref = base + type + '/' + slug + '/'
     set_classes(options)
@@ -134,7 +134,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         if not base.endswith('/'):
             base += '/'
     except AttributeError as err:
-        raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
+        raise ValueError('github_project_url configuration value is not set ({0!s})'.format(str(err)))
 
     ref = base + text
     node = nodes.reference(rawtext, text[:6], refuri=ref, **options)

--- a/doc/sphinxext/math_dollar.py
+++ b/doc/sphinxext/math_dollar.py
@@ -33,7 +33,7 @@ def dollars_to_math(source):
     def repl(matchobj):
         global _data
         s = matchobj.group(0)
-        t = "___XXX_REPL_%d___" % len(_data)
+        t = "___XXX_REPL_{0:d}___".format(len(_data))
         _data[t] = s
         return t
     s = re.sub(r"({[^{}$]*\$[^{}$]*\$[^{}]*})", repl, s)

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -276,7 +276,7 @@ class ApiDocWriter(object):
 
         # Make a shorter version of the uri that omits the package name for
         # titles
-        uri_short = re.sub(r'^%s\.' % self.package_name,'',uri)
+        uri_short = re.sub(r'^{0!s}\.'.format(self.package_name),'',uri)
 
         head = '.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n'
         body = ''
@@ -343,8 +343,7 @@ class ApiDocWriter(object):
         elif match_type == 'package':
             patterns = self.package_skip_patterns
         else:
-            raise ValueError('Cannot interpret match type "%s"'
-                             % match_type)
+            raise ValueError('Cannot interpret match type "{0!s}"'.format(match_type))
         # Match to URI without package name
         L = len(self.package_name)
         if matchstr[:L] == self.package_name:
@@ -425,7 +424,7 @@ class ApiDocWriter(object):
         written_modules = []
 
         for ulm, mods in module_by_ulm.items():
-            print("Generating docs for %s:" % ulm)
+            print("Generating docs for {0!s}:".format(ulm))
             document_head = []
             document_body = []
 
@@ -505,5 +504,5 @@ class ApiDocWriter(object):
         w("=" * len(title) + "\n\n")
         w('.. toctree::\n\n')
         for f in self.written_modules:
-            w('   %s\n' % os.path.join(relpath,f))
+            w('   {0!s}\n'.format(os.path.join(relpath,f)))
         idx.close()

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion as V
 #*****************************************************************************
 
 def abort(error):
-    print('*WARNING* API documentation not generated: %s' % error)
+    print('*WARNING* API documentation not generated: {0!s}'.format(error))
     exit()
 
 
@@ -43,12 +43,12 @@ def writeapi(package, outdir, source_version, other_defines=True):
     docwriter = ApiDocWriter(package, rst_extension='.rst',
                              other_defines=other_defines)
 
-    docwriter.package_skip_patterns += [r'\.%s$' % package,
+    docwriter.package_skip_patterns += [r'\.{0!s}$'.format(package),
                                         r'.*test.*$',
                                         r'\.version.*$']
     docwriter.write_api_docs(outdir)
     docwriter.write_index(outdir, 'index', relative_to=outdir)
-    print('%d files written' % len(docwriter.written_modules))
+    print('{0:d} files written'.format(len(docwriter.written_modules)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:erramuzpe:aging?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:erramuzpe:aging?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)